### PR TITLE
Set up GitHub action to cross-compile the gem

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,0 +1,46 @@
+---
+  name: Cross Compile
+
+  on:
+    push:
+      tags:
+        - "v*"
+
+  jobs:
+    ci-data:
+      name: Fetch CI data
+      runs-on: ubuntu-latest
+      outputs:
+        result: ${{ steps.fetch.outputs.result }}
+      steps:
+        - uses: oxidize-rb/actions/fetch-ci-data@v1
+          id: fetch
+          with:
+            supported-ruby-platforms: true
+            stable-ruby-versions: |
+              exclude: [head]
+    cross-gem:
+      name: Compile native gem for ${{ matrix.platform }}
+      runs-on: ubuntu-latest
+      needs: ci-data
+      strategy:
+        fail-fast: false
+        matrix:
+          platform: ${{ fromJSON(needs.ci-data.outputs.result).supported-ruby-platforms }}
+      steps:
+        - uses: actions/checkout@v3
+
+        - uses: ruby/setup-ruby@v1
+          with:
+            ruby-version: "3.2"
+
+        - uses: oxidize-rb/actions/cross-gem@v1
+          id: cross-gem
+          with:
+            platform: ${{ matrix.platform }}
+            ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ',') }}
+
+        - uses: actions/upload-artifact@v3
+          with:
+            name: cross-gem
+            path: ${{ steps.cross-gem.outputs.gem-path }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.62.0"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6720a8b7b2d39dd533285ed438d458f65b31b5c257e6ac7bb3d7e82844dd722"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -28,14 +28,14 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "cexpr"
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "magnus"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b560c3c0284c9ec7c30b7ba823896387423225add3f107213a794b73853c7505"
+checksum = "5b7a37670bc433d081ef5846d5589381fabd8d3410ad3b59faa6b1b4c9c3cbce"
 dependencies = [
  "magnus-macros",
  "rb-sys",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "minimal-lexical"
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -242,18 +242,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.79"
+version = "0.9.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939fb78db3e4f26665c1d4c7b91ca66d3578335a19aba552d4a6445811d07072"
+checksum = "a57240b308b155b09dce81e32829966a99f52d1088b45957e4283e526c5317a1"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.79"
+version = "0.9.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335a95eb0420d52fa94ef12019df3c2c250c6b19cbb3c60bd05cb7e9c362072c"
+checksum = "f24ce877a4c5d07f06f6aa6fec3ac95e4b357b9f73b0f5445d8cbb7266d410e8"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -261,7 +261,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn 1.0.109",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -272,9 +272,9 @@ checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustc-hash"
@@ -313,29 +313,29 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "serde"
-version = "1.0.174"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.174"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -350,9 +350,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "syn"
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["ext/mrml"]

--- a/Rakefile
+++ b/Rakefile
@@ -3,24 +3,22 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rake/extensiontask'
+require 'rb_sys/extensiontask'
 
-PLATFORM = %w[
-  x86-linux x86_64-linux aarch64-linux
-  x86-mingw32 x64-mingw-ucrt x64-mingw32
-  x86_64-darwin arm64-darwin
-]
+GEMSPEC = Gem::Specification.load('mrml.gemspec')
+
+RbSys::ExtensionTask.new('mrml', GEMSPEC) do |ext|
+  ext.lib_dir = 'lib/mrml'
+end
+
+task :native, [:platform] do |_t, platform:|
+  sh 'bundle', 'exec', 'rb-sys-dock', '--platform', platform, '--build'
+end
 
 Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-Rake::ExtensionTask.new('mrml') do |ext|
-  ext.lib_dir        = 'lib/mrml'
-  ext.source_pattern = '*.{rs,toml}'
-  ext.cross_compile  = true
-  ext.cross_platform = PLATFORM
 end
 
 task default: %i[clobber compile test]


### PR DESCRIPTION
This PR addresses #1.

Cross-compilation is started as soon as a git tag is pushed that matches the name "v*". The resulting cross-compiled gems are uploaded to the action's artifacts (please see this [test workflow run](https://github.com/paulgoetze/mrml-ruby/actions/runs/6101341266) in my fork.) The downloadable `cross-gem` zip file contains all the cross-compiled gem packages.

The current cross-compilation targets (i.e. resulting gem suffixes) are: 
- arm-linux
- aarch64-linux
- arm64-darwin
- x64-mingw-ucrt
- x64-mingw-32
- x86_64-darwin
- x86_64-linux
- x86_64-linux-musl

**:notebook:  Some more notes:**

- The cross-gem action needed a top-level `Cargo.toml` with a workspace reference to the `Cargo.toml` in `ext/mrml/` (and in result also to move the `Cargo.lock`) to work, that's why the Cargo.lock changed places (and pulled in some minor updates - because I removed and rebuilt it from the gem's root directory).
- I don't know what your current release flow is, @jonian, but  I guess one could also automate publishing the cross-compiled gems somehow via the rubygems API, so that you don't have to push each of the cross-compiled gems manually. Nevertheless, the generated artifact at least already provides all the cross-compiled gem versions for a published tag :)