### PR TITLE
Add mention that Rust isn't a requirement anymore for installing the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MRML Ruby
 
-Ruby wrapper for [MRML](https://github.com/jdrouet/mrml), the [MJML](https://mjml.io) markup language implementation in Rust. Rust must be available on your system to install this gem.
+Ruby wrapper for [MRML](https://github.com/jdrouet/mrml), the [MJML](https://mjml.io) markup language implementation in Rust. Rust must be available on your system to install this gem if you use a version below [v1.4.2](https://github.com/hardpixel/mrml-ruby/releases/tag/v1.4.2).
 
 [![Gem Version](https://badge.fury.io/rb/mrml.svg)](https://badge.fury.io/rb/mrml)
 [![Build](https://github.com/hardpixel/mrml-ruby/actions/workflows/build.yml/badge.svg)](https://github.com/hardpixel/mrml-ruby/actions/workflows/build.yml)


### PR DESCRIPTION
I think it is worth calling this out, otherwise, people will think it is still a requirement and may end up not using the gem due to it introducing Rust as a dependency