### PR TITLE
support ruby-head by using stable-api-compiled-fallback feature of rb-sys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.7', '3.2', '3.3']
+        ruby: ['2.7', '3.2', '3.3', 'ruby-head']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ version = "0.1.0"
 dependencies = [
  "magnus",
  "mrml 4.0.1",
+ "rb-sys",
  "serde",
  "serde_json",
 ]

--- a/ext/mrml/Cargo.toml
+++ b/ext/mrml/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 mrml = "4.0"
 magnus = "0.5"
+rb-sys = { version = "*", features = ["stable-api-compiled-fallback"] }
 
 [dependencies.serde]
 version = "1.0"


### PR DESCRIPTION
I want to use mrml-ruby in my project, but was concerned it would block me from updating to Ruby 3.4 based on https://github.com/hardpixel/mrml-ruby/issues/12. Looking around from the comment on that issue, I found out about the `stable-api-compiled-fallback` feature of rb-sys (see https://github.com/oxidize-rb/rb-sys/pull/229 for details).

I am not familiar with rust tooling or how to use rust packages within ruby, but piecing together from similar PRs in similar projects, I wanted to submit this PR as a starting point. I referenced these PRs:

https://github.com/gjtorikian/commonmarker/pull/288
https://github.com/IAPark/tiktoken_ruby/pull/14
