### PR TITLE
CI: Use maintained GitHub Action for Rust dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR switches to a maintained Action for installing Rust: https://github.com/dtolnay/rust-toolchain

Essentially the same change as https://github.com/uutils/parse_datetime/pull/59

Avoids deprecation warnings from GitHub Actions.