### PR TITLE
Add TruffleRuby support by replacing Magnus with rb-sys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.2', '3.3', '3.4', '4.0']
+        ruby: ['3.2', '3.3', '3.4', '4.0', 'truffleruby']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,29 +188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "magnus"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b36a5b126bbe97eb0d02d07acfeb327036c6319fd816139a49824a83b7f9012"
-dependencies = [
- "magnus-macros",
- "rb-sys",
- "rb-sys-env",
- "seq-macro",
-]
-
-[[package]]
-name = "magnus-macros"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47607461fd8e1513cb4f2076c197d8092d921a1ea75bd08af97398f593751892"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,8 +203,8 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 name = "mrml"
 version = "0.1.0"
 dependencies = [
- "magnus",
  "mrml 5.1.0",
+ "rb-sys",
  "serde",
  "serde_json",
 ]
@@ -308,12 +285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rb-sys-env"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca7ad6a7e21e72151d56fe2495a259b5670e204c3adac41ee7ef676ea08117a"
-
-[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,12 +324,6 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"

--- a/ext/mrml/Cargo.toml
+++ b/ext/mrml/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 mrml = "5.1"
-magnus = "0.8"
+rb-sys = "0.9"
 
 [dependencies.serde]
 version = "1.0"

--- a/ext/mrml/src/lib.rs
+++ b/ext/mrml/src/lib.rs
@@ -1,46 +1,40 @@
-use magnus::{
-  function, method, prelude::*, value::Lazy, Ruby,
-  Error, ExceptionClass, RModule
-};
+use std::ffi::c_void;
+use std::os::raw::{c_char, c_long};
+use std::panic::{self, AssertUnwindSafe};
+use std::ptr;
+use std::slice;
+use std::{mem, result};
 
 use mrml::mjml::Mjml;
 use mrml::prelude::print::Printable;
 use mrml::prelude::render::RenderOptions;
 
-static MODULE: Lazy<RModule> =
-  Lazy::new(|ruby| ruby.class_object().const_get("MRML").unwrap());
+use rb_sys::{
+  rb_cObject, rb_data_type_struct__bindgen_ty_1, rb_data_type_t,
+  rb_data_typed_object_wrap, rb_define_class_under, rb_define_method,
+  rb_define_module, rb_define_singleton_method, rb_eTypeError, rb_exc_new,
+  rb_exc_raise, rb_intern, rb_obj_class, rb_utf8_str_new, rb_const_get,
+  rb_undef_alloc_func, ruby_value_type, size_t, VALUE, Qnil, RB_TYPE,
+  RSTRING_LEN, RSTRING_PTR, RTYPEDDATA_GET_DATA, RTYPEDDATA_P,
+  RTYPEDDATA_TYPE
+};
 
-static ERROR: Lazy<ExceptionClass> =
-  Lazy::new(|ruby| ruby.get_inner(&MODULE).const_get("Error").unwrap());
-
-fn mrml_error() -> ExceptionClass {
-  Ruby::get().unwrap().get_inner(&ERROR)
-}
-
-macro_rules! error {
-  ($ex:ident) => {
-    Error::new(mrml_error(), $ex.to_string())
-  };
-}
-
-#[magnus::wrap(class = "MRML::Template", free_immediately, size)]
+#[derive(Clone)]
 struct Template {
   res: Mjml
 }
 
 impl Template {
-  fn new(input: String) -> Result<Self, Error> {
-    match mrml::parse(&input) {
-      Ok(output) => Ok(Self { res: output.element }),
-      Err(ex) => Err(error!(ex))
-    }
+  fn new(input: &str) -> Result<Self, String> {
+    mrml::parse(input)
+      .map(|output| Self { res: output.element })
+      .map_err(|ex| ex.to_string())
   }
 
-  fn from_json(input: String) -> Result<Self, Error> {
-    match serde_json::from_str::<Mjml>(&input) {
-      Ok(res) => Ok(Self { res }),
-      Err(ex) => Err(error!(ex))
-    }
+  fn from_json(input: &str) -> Result<Self, String> {
+    serde_json::from_str::<Mjml>(input)
+      .map(|res| Self { res })
+      .map_err(|ex| ex.to_string())
   }
 
   fn get_title(&self) -> Option<String> {
@@ -51,48 +45,257 @@ impl Template {
     self.res.get_preview()
   }
 
-  fn to_mjml(&self) -> String {
-    self.res.print_dense().unwrap()
+  fn to_mjml(&self) -> Result<String, String> {
+    self.res.print_dense().map_err(|ex| ex.to_string())
   }
 
-  fn to_json(&self) -> Result<String, Error> {
-    match serde_json::to_string(&self.res) {
-      Ok(res) => Ok(res),
-      Err(ex) => Err(error!(ex))
-    }
+  fn to_json(&self) -> Result<String, String> {
+    serde_json::to_string(&self.res).map_err(|ex| ex.to_string())
   }
 
-  fn to_html(&self) -> Result<String, Error> {
-    match self.res.render(&RenderOptions::default()) {
-      Ok(res) => Ok(res),
-      Err(ex) => Err(error!(ex))
-    }
+  fn to_html(&self) -> Result<String, String> {
+    self.res.render(&RenderOptions::default()).map_err(|ex| ex.to_string())
   }
 }
 
-impl Clone for Template {
-  fn clone(&self) -> Self {
-    Self::new(self.to_mjml()).unwrap()
+const TEMPLATE_TYPE_NAME: &[u8] = b"MRML::Template\0";
+
+enum AppError {
+  Mrml(String),
+  Type(String)
+}
+
+impl From<String> for AppError {
+  fn from(error: String) -> Self {
+    Self::Mrml(error)
   }
 }
 
-#[magnus::init]
-fn init(ruby: &Ruby) -> Result<(), Error> {
-  let module = ruby.define_module("MRML")?;
-  let class = module.define_class("Template", ruby.class_object())?;
+impl From<std::str::Utf8Error> for AppError {
+  fn from(_error: std::str::Utf8Error) -> Self {
+    Self::Type("input string must be valid UTF-8".to_string())
+  }
+}
 
-  class.define_singleton_method("new", function!(Template::new, 1))?;
-  class.define_singleton_method("from_json", function!(Template::from_json, 1))?;
+struct TemplateDataType(rb_data_type_t);
 
-  class.define_method("title", method!(Template::get_title, 0))?;
-  class.define_method("preview", method!(Template::get_preview, 0))?;
+// Ruby treats rb_data_type_t as immutable process-wide metadata after init.
+unsafe impl Sync for TemplateDataType {}
 
-  class.define_method("to_mjml", method!(Template::to_mjml, 0))?;
-  class.define_method("to_json", method!(Template::to_json, 0))?;
-  class.define_method("to_html", method!(Template::to_html, 0))?;
+static TEMPLATE_TYPE: TemplateDataType = TemplateDataType(
+  rb_data_type_t {
+    wrap_struct_name: TEMPLATE_TYPE_NAME.as_ptr() as *const c_char,
+    function: rb_data_type_struct__bindgen_ty_1 {
+      dmark: None,
+      dfree: Some(template_free),
+      dsize: Some(template_size),
+      dcompact: None,
+      reserved: [ptr::null_mut(); 1]
+    },
+    parent: ptr::null(),
+    data: ptr::null_mut(),
+    flags: 0
+  }
+);
 
-  class.define_method("clone", method!(Template::clone, 0))?;
-  class.define_method("dup", method!(Template::clone, 0))?;
+unsafe extern "C" fn template_free(ptr: *mut c_void) {
+  if !ptr.is_null() {
+    drop(Box::from_raw(ptr as *mut Template));
+  }
+}
 
-  Ok(())
+unsafe extern "C" fn template_size(_ptr: *const c_void) -> size_t {
+  mem::size_of::<Template>() as size_t
+}
+
+fn cstr(bytes: &'static [u8]) -> *const c_char {
+  bytes.as_ptr() as *const c_char
+}
+
+type RubyMethod = unsafe extern "C" fn() -> VALUE;
+type RubyMethod0 = unsafe extern "C" fn(VALUE) -> VALUE;
+type RubyMethod1 = unsafe extern "C" fn(VALUE, VALUE) -> VALUE;
+
+unsafe fn method0(func: RubyMethod0) -> Option<RubyMethod> {
+  Some(mem::transmute::<RubyMethod0, RubyMethod>(func))
+}
+
+unsafe fn method1(func: RubyMethod1) -> Option<RubyMethod> {
+  Some(mem::transmute::<RubyMethod1, RubyMethod>(func))
+}
+
+fn template_type() -> *const rb_data_type_t {
+  &TEMPLATE_TYPE.0
+}
+
+unsafe fn module() -> VALUE {
+  rb_define_module(cstr(b"MRML\0"))
+}
+
+unsafe fn error_class() -> VALUE {
+  rb_const_get(module(), rb_intern(cstr(b"Error\0")))
+}
+
+unsafe fn raise_error(class: VALUE, message: String) -> ! {
+  let exception = rb_exc_new(
+    class,
+    message.as_ptr() as *const c_char,
+    message.len() as c_long
+  );
+
+  drop(message);
+  rb_exc_raise(exception)
+}
+
+unsafe fn raise_mrml_error(message: String) -> ! {
+  raise_error(error_class(), message)
+}
+
+unsafe fn raise_type_error(message: String) -> ! {
+  raise_error(rb_eTypeError, message)
+}
+
+unsafe fn ruby_callback<F>(func: F) -> VALUE
+where
+  F: FnOnce() -> result::Result<VALUE, AppError>
+{
+  match panic::catch_unwind(AssertUnwindSafe(func)) {
+    Ok(Ok(value)) => value,
+    Ok(Err(AppError::Mrml(ex))) => raise_mrml_error(ex),
+    Ok(Err(AppError::Type(ex))) => raise_type_error(ex),
+    Err(_) => raise_mrml_error("internal panic in MRML native extension".to_string())
+  }
+}
+
+unsafe fn with_ruby_str<T, F>(value: VALUE, func: F) -> result::Result<T, AppError>
+where
+  F: FnOnce(&str) -> result::Result<T, AppError>
+{
+  if RB_TYPE(value) != ruby_value_type::RUBY_T_STRING {
+    return Err(AppError::Type("wrong argument type".to_string()));
+  }
+
+  let ptr = RSTRING_PTR(value);
+  let len = RSTRING_LEN(value) as usize;
+  let bytes = slice::from_raw_parts(ptr as *const u8, len);
+  let input = std::str::from_utf8(bytes)?;
+  let result = func(input);
+
+  rb_sys::rb_gc_guard!(value);
+
+  result
+}
+
+unsafe fn string_to_value(value: String) -> VALUE {
+  rb_utf8_str_new(value.as_ptr() as *const c_char, value.len() as c_long)
+}
+
+unsafe fn wrap_template(class: VALUE, template: Template) -> VALUE {
+  let ptr = Box::into_raw(Box::new(template)) as *mut c_void;
+  rb_data_typed_object_wrap(class, ptr, template_type())
+}
+
+unsafe fn get_template<'a>(value: VALUE) -> result::Result<&'a Template, AppError> {
+  if !RTYPEDDATA_P(value) || RTYPEDDATA_TYPE(value) != template_type() {
+    return Err(AppError::Type("wrong argument type".to_string()));
+  }
+
+  let ptr = RTYPEDDATA_GET_DATA(value) as *const Template;
+
+  if ptr.is_null() {
+    return Err(AppError::Type("uninitialized MRML::Template".to_string()));
+  }
+
+  Ok(&*ptr)
+}
+
+unsafe extern "C" fn template_new(class: VALUE, input: VALUE) -> VALUE {
+  ruby_callback(|| {
+    with_ruby_str(input, |input| {
+      Template::new(input)
+        .map(|template| wrap_template(class, template))
+        .map_err(AppError::from)
+    })
+  })
+}
+
+unsafe extern "C" fn template_from_json(class: VALUE, input: VALUE) -> VALUE {
+  ruby_callback(|| {
+    with_ruby_str(input, |input| {
+      Template::from_json(input)
+        .map(|template| wrap_template(class, template))
+        .map_err(AppError::from)
+    })
+  })
+}
+
+unsafe extern "C" fn template_title(value: VALUE) -> VALUE {
+  ruby_callback(|| {
+    Ok(match get_template(value)?.get_title() {
+      Some(title) => string_to_value(title),
+      None => Qnil.into()
+    })
+  })
+}
+
+unsafe extern "C" fn template_preview(value: VALUE) -> VALUE {
+  ruby_callback(|| {
+    Ok(match get_template(value)?.get_preview() {
+      Some(preview) => string_to_value(preview),
+      None => Qnil.into()
+    })
+  })
+}
+
+unsafe extern "C" fn template_to_mjml(value: VALUE) -> VALUE {
+  ruby_callback(|| {
+    get_template(value)?
+      .to_mjml()
+      .map(|output| string_to_value(output))
+      .map_err(AppError::from)
+  })
+}
+
+unsafe extern "C" fn template_to_json(value: VALUE) -> VALUE {
+  ruby_callback(|| {
+    get_template(value)?
+      .to_json()
+      .map(|output| string_to_value(output))
+      .map_err(AppError::from)
+  })
+}
+
+unsafe extern "C" fn template_to_html(value: VALUE) -> VALUE {
+  ruby_callback(|| {
+    get_template(value)?
+      .to_html()
+      .map(|output| string_to_value(output))
+      .map_err(AppError::from)
+  })
+}
+
+unsafe extern "C" fn template_clone(value: VALUE) -> VALUE {
+  ruby_callback(|| {
+    Ok(wrap_template(rb_obj_class(value), get_template(value)?.clone()))
+  })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Init_mrml() {
+  let module = module();
+  let class = rb_define_class_under(module, cstr(b"Template\0"), rb_cObject);
+  rb_undef_alloc_func(class);
+
+  rb_define_singleton_method(class, cstr(b"new\0"), method1(template_new), 1);
+  rb_define_singleton_method(class, cstr(b"from_json\0"), method1(template_from_json), 1);
+
+  rb_define_method(class, cstr(b"title\0"), method0(template_title), 0);
+  rb_define_method(class, cstr(b"preview\0"), method0(template_preview), 0);
+
+  rb_define_method(class, cstr(b"to_mjml\0"), method0(template_to_mjml), 0);
+  rb_define_method(class, cstr(b"to_json\0"), method0(template_to_json), 0);
+  rb_define_method(class, cstr(b"to_html\0"), method0(template_to_html), 0);
+
+  rb_define_method(class, cstr(b"clone\0"), method0(template_clone), 0);
+  rb_define_method(class, cstr(b"dup\0"), method0(template_clone), 0);
 }

--- a/ext/mrml/src/lib.rs
+++ b/ext/mrml/src/lib.rs
@@ -1,5 +1,5 @@
 use std::ffi::c_void;
-use std::os::raw::{c_char, c_long};
+use std::os::raw::{c_char, c_int, c_long};
 use std::panic::{self, AssertUnwindSafe};
 use std::ptr;
 use std::slice;
@@ -10,13 +10,13 @@ use mrml::prelude::print::Printable;
 use mrml::prelude::render::RenderOptions;
 
 use rb_sys::{
-  rb_cObject, rb_data_type_struct__bindgen_ty_1, rb_data_type_t,
+  rb_cObject, rb_check_string_type, rb_const_get,
+  rb_data_type_struct__bindgen_ty_1, rb_data_type_t,
   rb_data_typed_object_wrap, rb_define_class_under, rb_define_method,
   rb_define_module, rb_define_singleton_method, rb_eTypeError, rb_exc_new,
-  rb_exc_raise, rb_intern, rb_obj_class, rb_utf8_str_new, rb_const_get,
-  rb_undef_alloc_func, ruby_value_type, size_t, VALUE, Qnil, RB_TYPE,
-  RSTRING_LEN, RSTRING_PTR, RTYPEDDATA_GET_DATA, RTYPEDDATA_P,
-  RTYPEDDATA_TYPE
+  rb_exc_raise, rb_intern, rb_jump_tag, rb_obj_class, rb_protect,
+  rb_undef_alloc_func, rb_utf8_str_new, size_t, VALUE, Qnil, RSTRING_LEN,
+  RSTRING_PTR, RTYPEDDATA_GET_DATA, RTYPEDDATA_P, RTYPEDDATA_TYPE
 };
 
 #[derive(Clone)]
@@ -62,7 +62,8 @@ const TEMPLATE_TYPE_NAME: &[u8] = b"MRML::Template\0";
 
 enum AppError {
   Mrml(String),
-  Type(String)
+  Type(String),
+  RubyJump(c_int)
 }
 
 impl From<String> for AppError {
@@ -163,24 +164,43 @@ where
     Ok(Ok(value)) => value,
     Ok(Err(AppError::Mrml(ex))) => raise_mrml_error(ex),
     Ok(Err(AppError::Type(ex))) => raise_type_error(ex),
+    Ok(Err(AppError::RubyJump(state))) => rb_jump_tag(state),
     Err(_) => raise_mrml_error("internal panic in MRML native extension".to_string())
   }
+}
+
+unsafe extern "C" fn check_string_type(value: VALUE) -> VALUE {
+  rb_check_string_type(value)
+}
+
+unsafe fn string_value(value: VALUE) -> result::Result<VALUE, AppError> {
+  let mut state = 0;
+  let string = rb_protect(Some(check_string_type), value, &mut state);
+
+  if state != 0 {
+    return Err(AppError::RubyJump(state));
+  }
+
+  let nil: VALUE = Qnil.into();
+  if string == nil {
+    return Err(AppError::Type("wrong argument type".to_string()));
+  }
+
+  Ok(string)
 }
 
 unsafe fn with_ruby_str<T, F>(value: VALUE, func: F) -> result::Result<T, AppError>
 where
   F: FnOnce(&str) -> result::Result<T, AppError>
 {
-  if RB_TYPE(value) != ruby_value_type::RUBY_T_STRING {
-    return Err(AppError::Type("wrong argument type".to_string()));
-  }
-
-  let ptr = RSTRING_PTR(value);
-  let len = RSTRING_LEN(value) as usize;
+  let string = string_value(value)?;
+  let ptr = RSTRING_PTR(string);
+  let len = RSTRING_LEN(string) as usize;
   let bytes = slice::from_raw_parts(ptr as *const u8, len);
   let input = std::str::from_utf8(bytes)?;
   let result = func(input);
 
+  rb_sys::rb_gc_guard!(string);
   rb_sys::rb_gc_guard!(value);
 
   result

--- a/test/mrml_test.rb
+++ b/test/mrml_test.rb
@@ -35,6 +35,14 @@ class MrmlTest < Minitest::Test
     assert_match 'Hello World', result
   end
 
+  def test_that_it_accepts_string_like_templates
+    result = ::MRML.to_html(string_like(valid_template))
+
+    refute_match %r{</?mj.+?>}, result
+    assert_match %r{</?body>}, result
+    assert_match 'Hello World', result
+  end
+
   def test_that_it_generates_json
     result = ::MRML.to_json(valid_template)
     assert_match '"type":"mjml"', result
@@ -129,5 +137,17 @@ class MrmlTest < Minitest::Test
         </mj-body>
       </mjml>
     MJML
+  end
+
+  def string_like(value)
+    Class.new do
+      define_method(:initialize) do |input|
+        @input = input
+      end
+
+      define_method(:to_str) do
+        String.new(@input)
+      end
+    end.new(value)
   end
 end

--- a/test/mrml_test.rb
+++ b/test/mrml_test.rb
@@ -52,9 +52,40 @@ class MrmlTest < Minitest::Test
     assert_match %r{</?mj.+?>}, result.to_mjml
   end
 
+  def test_that_returned_strings_are_utf8
+    template = ::MRML::Template.new(utf8_template)
+
+    assert_equal Encoding::UTF_8, template.title.encoding
+    assert_equal Encoding::UTF_8, template.preview.encoding
+    assert_equal Encoding::UTF_8, template.to_mjml.encoding
+    assert_equal Encoding::UTF_8, template.to_json.encoding
+    assert_equal Encoding::UTF_8, template.to_html.encoding
+  end
+
+  def test_that_it_clones_template
+    template = ::MRML::Template.new(valid_template)
+    clone = template.clone
+
+    refute_same template, clone
+    assert_instance_of ::MRML::Template, clone
+    assert_equal template.to_mjml, clone.to_mjml
+  end
+
   def test_that_it_raises_an_exception
     assert_raises ::MRML::Error do
       ::MRML.to_html(invalid_template)
+    end
+  end
+
+  def test_that_it_raises_type_error_for_non_string_template
+    assert_raises TypeError do
+      ::MRML::Template.new(Object.new)
+    end
+  end
+
+  def test_that_it_raises_type_error_for_invalid_utf8_template
+    assert_raises TypeError do
+      ::MRML::Template.new("\xFF".b)
     end
   end
 
@@ -80,5 +111,23 @@ class MrmlTest < Minitest::Test
 
   def hash_template
     @hash_template ||= JSON.parse(json_template)
+  end
+
+  def utf8_template
+    <<~MJML
+      <mjml>
+        <mj-head>
+          <mj-title>Olá Newsletter</mj-title>
+          <mj-preview>Prévia</mj-preview>
+        </mj-head>
+        <mj-body>
+          <mj-section>
+            <mj-column>
+              <mj-text>Olá Mundo</mj-text>
+            </mj-column>
+          </mj-section>
+        </mj-body>
+      </mjml>
+    MJML
   end
 end


### PR DESCRIPTION
This refactors the native Rust extension to use direct rb-sys bindings instead of Magnus, allowing the gem to compile and run on TruffleRuby while preserving MRI support.

Magnus depends on CRuby internals that are not available on TruffleRuby, so the native boundary now uses public Ruby C-API-compatible rb-sys calls only.

Changes

- Replace magnus with rb-sys in the native extension.
- Implement MRML::Template wrapping with Ruby typed data.
- Add explicit Ruby callback error handling to avoid raising across Rust stack frames.
- Use zero-copy string reads for Ruby input strings.
- Return UTF-8 tagged Ruby strings from native output.
- Implement clone / dup using Rust-side AST cloning instead of serialize-and-reparse.
- Add TruffleRuby to the GitHub Actions Ruby matrix.
- Add tests for TruffleRuby-relevant type handling, invalid UTF-8 input, UTF-8 output encoding, and clone behavior.
- Document TruffleRuby source-install support.

Verification

Tested successfully on both engines:

RBENV_VERSION=truffleruby-34.0.1 bundle exec rake clobber compile test RBENV_VERSION=3.4.9 bundle exec rake clobber compile test

Both passed with:

14 runs, 28 assertions, 0 failures, 0 errors, 0 skips